### PR TITLE
[FIX] filter state not in cancel

### DIFF
--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -47,7 +47,7 @@ class PurchaseOrderLine(models.Model):
     def _compute_all_invoices_approved(self):
         if self.invoice_lines:
             self.all_invoices_approved = \
-                not any(inv_line.invoice_id.state in ['draft', 'cancel']
+                not any(inv_line.invoice_id.state == 'draft'
                         for inv_line in self.invoice_lines)
         else:
             self.all_invoices_approved = False


### PR DESCRIPTION
แก้ไขให้ระบบ filter เฉพาะ state ที่ไม่ใช่ cancel เท่านั้น
deployment : restart only

COD transfer is allow only when all invoice(s) are fully paid
Issue : https://mobileapp.nstda.or.th/redmine/issues/4958